### PR TITLE
Adding Short codes

### DIFF
--- a/_extensions/wordcount/_extension.yml
+++ b/_extensions/wordcount/_extension.yml
@@ -8,10 +8,9 @@ contributes:
   format:
     common: 
       filters: 
-      - at: pre-render
-        path: "citeproc.lua"
-      - at: pre-render
-        path: "wordcount.lua"
+      - citeproc.lua
+      - wordcount.lua
+      - quarto
       citeproc: false
     html: default
     pdf: default

--- a/_extensions/wordcount/_extension.yml
+++ b/_extensions/wordcount/_extension.yml
@@ -1,6 +1,6 @@
 title: Quarto Word Count
-author: Andrew Heiss
-version: 1.1.4
+author: Andrew Heiss, Justin Landis
+version: 1.1.5
 quarto-required: ">=1.3.0"
 contributes:
   shortcodes: 

--- a/_extensions/wordcount/_extension.yml
+++ b/_extensions/wordcount/_extension.yml
@@ -3,6 +3,8 @@ author: Andrew Heiss
 version: 1.1.2
 quarto-required: ">=1.3.0"
 contributes:
+  shortcodes: 
+    - "words.lua"
   format:
     common: 
       filters: 

--- a/_extensions/wordcount/_extension.yml
+++ b/_extensions/wordcount/_extension.yml
@@ -1,6 +1,6 @@
 title: Quarto Word Count
 author: Andrew Heiss
-version: 1.1.3
+version: 1.1.4
 quarto-required: ">=1.3.0"
 contributes:
   shortcodes: 

--- a/_extensions/wordcount/_extension.yml
+++ b/_extensions/wordcount/_extension.yml
@@ -1,6 +1,6 @@
 title: Quarto Word Count
 author: Andrew Heiss
-version: 1.1.2
+version: 1.1.3
 quarto-required: ">=1.3.0"
 contributes:
   shortcodes: 

--- a/_extensions/wordcount/wordcount.lua
+++ b/_extensions/wordcount/wordcount.lua
@@ -12,6 +12,15 @@
 local body_words = 0
 local ref_words = 0
 local appendix_words = 0
+local total_words = 0
+
+function set_meta(m)
+  m.wordcount_body_words = body_words
+  m.wordcount_ref_words = ref_words
+  m.wordcount_appendix_words = appendix_words
+  m.wordcount_total_words = body_words + ref_words + appendix_words
+  return m
+end
 
 function is_table (blk)
    return (blk.t == "Table")
@@ -170,6 +179,8 @@ function Pandoc(el)
   end
   
   print()
+  -- modify meta data for words.lua
+  el.meta = set_meta(el.meta)
   
   return el
 end

--- a/_extensions/wordcount/wordcount.lua
+++ b/_extensions/wordcount/wordcount.lua
@@ -24,7 +24,7 @@ function set_meta(m)
   return m
 end
 
-function count_notes(blks)
+function count_words_in_notes(blks)
   local count = 0
   pandoc.walk_block(pandoc.Div(blks),  {
     Str = function(el)
@@ -42,10 +42,6 @@ end
 
 function is_image (blk)
    return (blk.t == "Image")
-end
-
-function is_note (blk)
-   return (blk.t == "Note")
 end
 
 function is_word (text)
@@ -80,26 +76,6 @@ function remove_all_refs (blks)
    local out = {}
    for _, b in pairs(blks) do
       if not (is_ref_div(b)) then
-	      table.insert(out, b)
-      end
-   end
-   return out
-end
-
-function remove_all_notes (blks)
-   local out = {}
-   for _, b in pairs(blks) do
-      if not (is_note(b)) then
-	      table.insert(out, b)
-      end
-   end
-   return out
-end
-
-function get_all_notes (blks)
-  local out = {}
-   for _, b in pairs(blks) do
-      if is_note(b) then
 	      table.insert(out, b)
       end
    end
@@ -152,7 +128,7 @@ body_count = {
   end,
   
   Note = function(el)
-    local count = count_notes(el)
+    local count = count_words_in_notes(el)
     body_words = body_words - count
   end
     
@@ -167,7 +143,7 @@ ref_count = {
   end,
   
   Note = function(el)
-    local count = count_notes(el)
+    local count = count_words_in_notes(el)
     ref_words = ref_words - count
   end
 }
@@ -182,7 +158,7 @@ appendix_count = {
   end,
   
   Note = function(el)
-    local count = count_notes(el)
+    local count = count_words_in_notes(el)
     appendix_words = appendix_words - count
   end
 }
@@ -214,7 +190,6 @@ function Pandoc(el)
     }
     )
     
-  --local notes = get_all_notes(untabled)
   pandoc.walk_block(pandoc.Div(all_notes), note_count)
   local note_words_out = note_words .. " words in notes section"
     
@@ -226,10 +201,8 @@ function Pandoc(el)
   -- Remove appendix divs from the blocks
   local unappended = remove_all_appendix(unreffed)
   
-  local unnoted = remove_all_notes(unappended)
-  
   -- Walk through the unappended blocks and count the words
-  pandoc.walk_block(pandoc.Div(unnoted), body_count)
+  pandoc.walk_block(pandoc.Div(unappended), body_count)
   -- notes and double counted by body
   --body_words = body_words - note_words
   local body_words_out = body_words .. " words in text body"

--- a/_extensions/wordcount/wordcount.lua
+++ b/_extensions/wordcount/wordcount.lua
@@ -24,11 +24,7 @@ function set_meta(m)
   return m
 end
 
-<<<<<<< HEAD
 function count_words(blks)
-=======
-function count_words(blks) 
->>>>>>> 8e82509dd1e272236216e2510092572bf4697162
   local count = 0
   pandoc.walk_block(pandoc.Div(blks), {
     Str = function(el)
@@ -72,12 +68,9 @@ function remove_all_tables_images (blks)
       Image = function(el)
         return {}
       end,
-<<<<<<< HEAD
       Figure = function(el)
         return {}
-      end,
-=======
->>>>>>> 8e82509dd1e272236216e2510092572bf4697162
+      end
       Div = function(el)
         if is_no_count_div(el) then
           return {}
@@ -97,11 +90,7 @@ function get_all_notes (blks)
   -- try and get notes
   pandoc.walk_block(pandoc.Div(blks),
     {
-<<<<<<< HEAD
       Note = function(el)
-=======
-      Note = function(el) 
->>>>>>> 8e82509dd1e272236216e2510092572bf4697162
         table.insert(all_notes, el)
       end
     })
@@ -226,26 +215,15 @@ function Pandoc(el)
   -- count words in notes
   pandoc.walk_block(pandoc.Div(all_notes), note_count)
   local note_words_out = note_words .. " words in notes section"
-<<<<<<< HEAD
 
-=======
-  
->>>>>>> 8e82509dd1e272236216e2510092572bf4697162
   -- Remove Tables, Images, and {.no-count} contents
   local untabled = remove_all_tables_images(el.blocks)
   -- Next remove notes
   local unnote = remove_all_notes(untabled)
-<<<<<<< HEAD
 
   refs_title = el.meta["reference-section-title"]
   local unreffed = remove_all_refs(unnote)
 
-=======
-  
-  refs_title = el.meta["reference-section-title"]
-  local unreffed = remove_all_refs(unnote)
-  
->>>>>>> 8e82509dd1e272236216e2510092572bf4697162
   -- Remove appendix divs from the blocks
   local unappended = remove_all_appendix(unreffed)
 
@@ -254,11 +232,7 @@ function Pandoc(el)
   -- notes and double counted by body
   --body_words = body_words - note_words
   local body_words_out = body_words .. " words in text body"
-<<<<<<< HEAD
-
-=======
   
->>>>>>> 8e82509dd1e272236216e2510092572bf4697162
   local refs = get_all_refs(unnote)
   pandoc.walk_block(pandoc.Div(refs), ref_count)
   local ref_words_out = ref_words .. " words in reference section"

--- a/_extensions/wordcount/wordcount.lua
+++ b/_extensions/wordcount/wordcount.lua
@@ -70,7 +70,7 @@ function remove_all_tables_images (blks)
       end,
       Figure = function(el)
         return {}
-      end
+      end,
       Div = function(el)
         if is_no_count_div(el) then
           return {}

--- a/_extensions/wordcount/wordcount.lua
+++ b/_extensions/wordcount/wordcount.lua
@@ -115,7 +115,6 @@ end
 function get_all_appendix (blks)
   local out = {}
    for _, b in pairs(blks) do
-     print(b)
       if is_appendix_div(b) then
           table.insert(out, b)
       end
@@ -138,7 +137,6 @@ body_count = {
   Str = function(el)
     -- we don't count a word if it's entirely punctuation:
     if is_word(el.text) then
-      print(el.text)
       body_words = body_words + 1
     end
   end,

--- a/_extensions/wordcount/wordcount.lua
+++ b/_extensions/wordcount/wordcount.lua
@@ -168,11 +168,6 @@ body_count = {
   CodeBlock = function(el)
     _,n = el.text:gsub("%S+","")
     body_words = body_words + n
-  end,
-  
-  Note = function(el)
-    local count = count_words(el)
-    body_words = body_words - count
   end
     
 }
@@ -183,11 +178,6 @@ ref_count = {
     if is_word(el.text) then
       ref_words = ref_words + 1
     end
-  end,
-  
-  Note = function(el)
-    local count = count_words(el)
-    ref_words = ref_words - count
   end
 }
 
@@ -198,11 +188,6 @@ appendix_count = {
     if is_word(el.text) then
       appendix_words = appendix_words + 1
     end
-  end,
-  
-  Note = function(el)
-    local count = count_words(el)
-    appendix_words = appendix_words - count
   end
 }
 

--- a/_extensions/wordcount/wordcount.lua
+++ b/_extensions/wordcount/wordcount.lua
@@ -24,9 +24,9 @@ function set_meta(m)
   return m
 end
 
-function count_words_in_notes(blks)
+function count_words(blks)
   local count = 0
-  pandoc.walk_block(pandoc.Div(blks),  {
+  pandoc.walk_block(pandoc.Div(blks), {
     Str = function(el)
       if is_word(el.text) then
         count = count + 1
@@ -36,12 +36,23 @@ function count_words_in_notes(blks)
   return count
 end
 
+function is_no_count_div (blk)
+  if (blk and blk.t=="Div" and blk.classes and #blk.classes > 0) then
+    for _, class in pairs(blk.classes) do
+      if class=="no-count" then
+        return true
+      end
+    end
+  end
+  return false
+end
+
 function is_table (blk)
    return (blk.t == "Table")
 end
 
 function is_image (blk)
-   return (blk.t == "Image")
+   return (blk.t == "Image" or blk.t == "Figure")
 end
 
 function is_word (text)
@@ -49,17 +60,52 @@ function is_word (text)
 end
 
 function remove_all_tables_images (blks)
-   local out = {}
-   for _, b in pairs(blks) do
-      if not (is_table(b) or is_image(b)) then
-	      table.insert(out, b)
+  return pandoc.walk_block(pandoc.Div(blks),
+    {
+      Table = function(el)
+        return {}
+      end,
+      Image = function(el)
+        return {}
+      end,
+      Figure = function(el)
+        return {}
+      end,
+      Div = function(el)
+        if is_no_count_div(el) then
+          return {}
+        end
+        return el
       end
-   end
-   return out
+    }).content
 end
 
 function is_ref_div (blk)
    return (blk.t == "Div" and blk.identifier == "refs")
+end
+
+function get_all_notes (blks)
+  -- Get all notes
+  local all_notes = {}
+  -- try and get notes
+  pandoc.walk_block(pandoc.Div(blks),
+    {
+      Note = function(el)
+        table.insert(all_notes, el)
+      end
+    })
+  return all_notes
+end
+
+function remove_all_notes (blks)
+  return pandoc.walk_block(
+    pandoc.Div(blks),
+    {
+      Note = function(el)
+        return {}
+      end
+    }
+  ).content
 end
 
 function get_all_refs (blks)
@@ -125,13 +171,8 @@ body_count = {
   CodeBlock = function(el)
     _,n = el.text:gsub("%S+","")
     body_words = body_words + n
-  end,
-  
-  Note = function(el)
-    local count = count_words_in_notes(el)
-    body_words = body_words - count
   end
-    
+
 }
 
 ref_count = {
@@ -140,11 +181,6 @@ ref_count = {
     if is_word(el.text) then
       ref_words = ref_words + 1
     end
-  end,
-  
-  Note = function(el)
-    local count = count_words_in_notes(el)
-    ref_words = ref_words - count
   end
 }
 
@@ -155,11 +191,6 @@ appendix_count = {
     if is_word(el.text) then
       appendix_words = appendix_words + 1
     end
-  end,
-  
-  Note = function(el)
-    local count = count_words_in_notes(el)
-    appendix_words = appendix_words - count
   end
 }
 
@@ -180,71 +211,66 @@ function Pandoc(el)
   end
 
   -- Get all notes
-  local all_notes = {}
-  -- try and get notes
-  local test = pandoc.walk_block(pandoc.Div(el.blocks),
-    {
-      Note = function(el) 
-        table.insert(all_notes, el)
-      end
-    }
-    )
-    
+  local all_notes = get_all_notes(el.blocks)
+  -- count words in notes
   pandoc.walk_block(pandoc.Div(all_notes), note_count)
   local note_words_out = note_words .. " words in notes section"
-    
+
+  -- Remove Tables, Images, and {.no-count} contents
   local untabled = remove_all_tables_images(el.blocks)
+  -- Next remove notes
+  local unnote = remove_all_notes(untabled)
 
   refs_title = el.meta["reference-section-title"]
-  local unreffed = remove_all_refs(untabled)
-  
+  local unreffed = remove_all_refs(unnote)
+
   -- Remove appendix divs from the blocks
   local unappended = remove_all_appendix(unreffed)
-  
+
   -- Walk through the unappended blocks and count the words
   pandoc.walk_block(pandoc.Div(unappended), body_count)
   -- notes and double counted by body
   --body_words = body_words - note_words
   local body_words_out = body_words .. " words in text body"
-  
-  local refs = get_all_refs(untabled)
+
+  local refs = get_all_refs(unnote)
   pandoc.walk_block(pandoc.Div(refs), ref_count)
   local ref_words_out = ref_words .. " words in reference section"
-  
+
   -- Get all appendix divs
   local appendix = get_all_appendix(unreffed)
   -- Walk through the appendix divs and count the words
   pandoc.walk_block(pandoc.Div(appendix), appendix_count)
   -- Print out the count of words in the appendix
   local appendix_words_out = appendix_words .. " words in appendix section"
-  
+
   local total_words_out = ""
   if appendix_words > 0 then
     total_words_out = body_words + ref_words .. " in the main text + references, with " .. appendix_words .. " in the appendix"
   else
     total_words_out = body_words + ref_words + appendix_words .. " total words"
   end
-  
-  local longest_out = math.max(string.len(body_words_out), 
-                               string.len(ref_words_out), 
+
+  local longest_out = math.max(string.len(body_words_out),
+                               string.len(ref_words_out),
                                string.len(total_words_out))
-  
+
   print(total_words_out)
   print(string.rep("-", longest_out))
   print(body_words_out)
   print(ref_words_out)
-  
+
   if note_words > 0 then
     print(note_words_out)
   end
-  
+
   if appendix_words > 0 then
     print(appendix_words_out)
   end
-  
+
   print()
   -- modify meta data for words.lua
   el.meta = set_meta(el.meta)
-  
+
   return el
 end

--- a/_extensions/wordcount/words.lua
+++ b/_extensions/wordcount/words.lua
@@ -1,19 +1,35 @@
 
+as_str = function(meta_value, name)
+  if (meta_value == nil) then
+    print("cannot find " .. name .. " in meta data")
+    return pandoc.Null()
+  end
+  return pandoc.Str(meta_value) 
+end
+
+as_num = function(meta_value, name)
+  if (meta_value == nil) then
+    print("cannot find " .. name .. " in meta data")
+    return 0
+  end
+  return meta_value
+end
+
 return {
   ['words-body'] = function(args, kwargs, meta)
-    return pandoc.Str(meta.wordcount_body_words)
+    return as_str(meta.wordcount_body_words, "wordcount_body_words")
   end,
   ['words-ref'] = function(args, kwargs, meta)
-    return pandoc.Str(meta.wordcount_ref_words)
+    return as_str(meta.wordcount_ref_words, "wordcount_ref_words")
   end,
   ['words-append'] = function(args, kwargs, meta)
-    return pandoc.Str(meta.wordcount_appendix_words)
+    return as_str(meta.wordcount_appendix_words, "wordcount_appendix_words")
   end,
   ['words-note'] = function(args, kwargs, meta)
-    return pandoc.Str(meta.wordcount_note_words)
+    return as_str(meta.wordcount_note_words, "wordcount_note_words")
   end,
   ['words-total'] = function(args, kwargs, meta)
-    return pandoc.Str(meta.wordcount_total_words)
+    return as_str(meta.wordcount_total_words, "wordcount_total_words")
   end,
   ['words-sum'] = function(args, kwargs, meta)
     local nargs = #args
@@ -25,16 +41,16 @@ return {
     local arg = args[1][1].text
     print(arg)
     if arg:match("body") then
-      count = count + meta.wordcount_body_words
+      count = count + as_num(meta.wordcount_body_words, "wordcount_total_words")
     end
     if arg:match("ref") then
-      count = count + meta.wordcount_ref_words
+      count = count + as_num(meta.wordcount_ref_words, "wordcount_ref_words")
     end
     if arg:match("append") then
-      count = count + meta.wordcount_appendix_words
+      count = count + as_num(meta.wordcount_appendix_words, "wordcount_appendix_words")
     end
     if arg:match("note") then
-      count = count + meta.wordcount_note_words
+      count = count + as_num(meta.wordcount_note_words, "wordcount_note_words")
     end
     return pandoc.Str(count - nargs)
   end

--- a/_extensions/wordcount/words.lua
+++ b/_extensions/wordcount/words.lua
@@ -1,10 +1,3 @@
-map = {
-  ['words-body'] = "wordcount_body_words",
-  ['words-ref'] = "wordcount_ref_words",
-  ['words-append'] = "wordcount_appendix_words",
-  ['words-note'] = "wordcount_note_words",
-  ['words-total'] = "wordcount_total_words"
-}
 
 return {
   ['words-body'] = function(args, kwargs, meta)

--- a/_extensions/wordcount/words.lua
+++ b/_extensions/wordcount/words.lua
@@ -1,0 +1,14 @@
+return {
+  ['words-body'] = function(args, kwargs, meta)
+    return pandoc.Str("words-body")
+  end,
+  ['words-ref'] = function(args, kwargs, meta)
+    return pandoc.Str(meta.wordcount_ref_words)
+  end,
+  ['words-append'] = function(args, kwargs, meta)
+    return pandoc. Str(meta.wordcount_appendix_words)
+  end,
+  ['words-total'] = function(args, kwargs, meta)
+    return pandoc. Str(meta.wordcount_total_words)
+  end
+}

--- a/_extensions/wordcount/words.lua
+++ b/_extensions/wordcount/words.lua
@@ -1,14 +1,48 @@
+map = {
+  ['words-body'] = "wordcount_body_words",
+  ['words-ref'] = "wordcount_ref_words",
+  ['words-append'] = "wordcount_appendix_words",
+  ['words-note'] = "wordcount_note_words",
+  ['words-total'] = "wordcount_total_words"
+}
+
 return {
   ['words-body'] = function(args, kwargs, meta)
-    return pandoc.Str("words-body")
+    return pandoc.Str(meta.wordcount_body_words)
   end,
   ['words-ref'] = function(args, kwargs, meta)
     return pandoc.Str(meta.wordcount_ref_words)
   end,
   ['words-append'] = function(args, kwargs, meta)
-    return pandoc. Str(meta.wordcount_appendix_words)
+    return pandoc.Str(meta.wordcount_appendix_words)
+  end,
+  ['words-note'] = function(args, kwargs, meta)
+    return pandoc.Str(meta.wordcount_note_words)
   end,
   ['words-total'] = function(args, kwargs, meta)
-    return pandoc. Str(meta.wordcount_total_words)
+    return pandoc.Str(meta.wordcount_total_words)
+  end,
+  ['words-sum'] = function(args, kwargs, meta)
+    local nargs = #args
+    local count = 0
+    if nargs == 0  then
+      return pandoc.Str(0)
+    end
+    print(args)
+    local arg = args[1][1].text
+    print(arg)
+    if arg:match("body") then
+      count = count + meta.wordcount_body_words
+    end
+    if arg:match("ref") then
+      count = count + meta.wordcount_ref_words
+    end
+    if arg:match("append") then
+      count = count + meta.wordcount_appendix_words
+    end
+    if arg:match("note") then
+      count = count + meta.wordcount_note_words
+    end
+    return pandoc.Str(count - nargs)
   end
 }

--- a/template.qmd
+++ b/template.qmd
@@ -25,19 +25,6 @@ references:
   type: article-journal
   volume: 3
 
-- id: Turing1936
-  author:
-    - family: Turing
-      given: Alan Mathison
-  citation-key: Turing1936
-  container-title: Journal of Math
-  issue: 345–363
-  issued:
-    - year: 1936
-  page: 230–265
-  title: On Computable Numbers, with an Application to the Entscheidungsproblem
-  type: article-journal
-  volume: 58
 ---
 
 ## Introduction
@@ -55,15 +42,29 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 
-## References 
+The word count for the document is {{< words-body >}}.[^1] This count does not include the number of words in the foot notes[^2].
+
+
+
+[^1]: But the total word count is {{< words-total >}}
+[^2]: The word count here is {{< words-note >}}
+
+some more information about the appendix [^4] ^[inline footnote1]
+
+## References [^3]
+
+[^3]: the word count for references is {{< words-ref >}}
 
 ::: {#refs}
 :::
 
-::: {#appendix-count}
 
-## Appendix {.appendix}
+
+<!-- ::: {#appendix-count} -->
+## Appendix ^[inline footnote2] {.appendix} 
 
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+<!-- ::: -->
 
-:::
+
+[^4]: The word count for Appendix is {{< words-append >}}

--- a/template.qmd
+++ b/template.qmd
@@ -42,7 +42,16 @@ references:
 
 ## Introduction
 
+::: {.no-count}
+
+You may use the `{.no-count}` class on a div to skip counting its contents, like this sentence.
+
+::: 
+
+
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua [@Lovelace1842]. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum [@Turing1936].
+
+
 
 | Column A | Column B |
 |----------|----------|

--- a/template.qmd
+++ b/template.qmd
@@ -25,6 +25,19 @@ references:
   type: article-journal
   volume: 3
 
+- id: Turing1936
+  author:
+    - family: Turing
+      given: Alan Mathison
+  citation-key: Turing1936
+  container-title: Journal of Math
+  issue: 345–363
+  issued:
+    - year: 1936
+  page: 230–265
+  title: On Computable Numbers, with an Application to the Entscheidungsproblem
+  type: article-journal
+  volume: 58
 ---
 
 ## Introduction
@@ -38,33 +51,33 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 
 : Here's a table with a caption that doesn't get counted
 
+Word counts can now be directly included with short codes. For example, use {{{< words-body >}}} to include body word count: {{< words-body >}}, or {{{< words-total >}}} to include all words tallied by this filter: {{< words-total >}}.[^1] You can also reliably count words in the footnotes which would have previously been included in whichever section they were.[^2]
+
+[^1]: **NOTE** short codes {{{< words-body >}}}, {{{< words-ref >}}}, {{{< words-append >}}}, and {{{< words-note >}}} do not overlap their counts.
+
+[^2]: Count Footnotes words with {{{< words-note >}}}: {{< words-note >}}
+
+This filter may not always produce accurate counts for documents that use short codes, specifically short codes that run after this filter. If a shortcode has multiple arguments but only return one word, then it is possible that the word count is inflated,[^3] and conversely deflated if it spawns more words.
+
+
+[^3]: An example in this extension is {{{< words-sum ARG >}}}, where `ARG` is formatted as "ref-note" or "body-append", etc, to count specific sections together. Since `words-sum` has two words to construct the short code but only one word is returned, the region that uses this short code is inflated by 1.
+
 ## Conclusion
 
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 
-The word count for the document is {{< words-body >}}.[^1] This count does not include the number of words in the foot notes[^2].
 
+## References [^4]
 
-
-[^1]: But the total word count is {{< words-total >}}
-[^2]: The word count here is {{< words-note >}}
-
-some more information about the appendix [^4] ^[inline footnote1]
-
-## References [^3]
-
-[^3]: the word count for references is {{< words-ref >}}
+[^4]: Count reference words with {{{< words-ref >}}}: {{< words-ref >}}
 
 ::: {#refs}
 :::
 
-
-
-<!-- ::: {#appendix-count} -->
-## Appendix ^[inline footnote2] {.appendix} 
+::: {#appendix-count}
+## Appendix [^5] {.appendix}
 
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-<!-- ::: -->
+:::
 
-
-[^4]: The word count for Appendix is {{< words-append >}}
+[^5]: Count Appendix words with {{{< words-append >}}}: {{< words-append >}}


### PR DESCRIPTION
Hello, Great extension for quarto! I noticed that it only prints to the console, so I looked into adding shortcodes to the project. Much of the explanation was included into the template.qmd.

The main contribution:

* short codes:
  * body count: {{< words-body >}}
  * reference count: {{< words-ref >}}
  * appendix count: {{< words-append >}}
  * note count: {{< words-note >}}
  * sum count: {{< words-sum ARG >}} where arg can be a concatenation of the other 4: body/ref/append/note.

Some other things:

* I added a separate count for notes. Some academic writing do not include foot notes towards word counts. In the current implementation, a foot note added in the body would be counted towards the body word count, and a foot note added in the references/appendix would be added to those counts. This pull request would separate these counts.
* fancy quotation characters `“` and `”` were being counted as individual words. The new `is_word` function now accounts for those.
* I have noticed that word count currently does not account for callout blocks. This is largely due to how quarto handles them, which is like a special RawInLine. I think, however, this will be fixed in quarto 1.4 as [the bug has been closed](https://github.com/quarto-dev/quarto-cli/issues/5661)