### PR TITLE
typo in words-sum shortcode

### DIFF
--- a/_extensions/wordcount/wordcount.lua
+++ b/_extensions/wordcount/wordcount.lua
@@ -271,6 +271,6 @@ function Pandoc(el)
   print()
   -- modify meta data for words.lua
   el.meta = set_meta(el.meta)
-
+  
   return el
 end

--- a/_extensions/wordcount/words.lua
+++ b/_extensions/wordcount/words.lua
@@ -37,9 +37,9 @@ return {
     if nargs == 0  then
       return pandoc.Str(0)
     end
-    print(args)
-    local arg = args[1][1].text
-    print(arg)
+    --print(args)
+    local arg = args[1]
+    --print(arg)
     if arg:match("body") then
       count = count + as_num(meta.wordcount_body_words, "wordcount_total_words")
     end

--- a/template.qmd
+++ b/template.qmd
@@ -74,7 +74,7 @@ Word counts can be directly included in your document with shortcodes, like so:[
 
 - Use `{{{< words-note >}}}` to include a count of the words in the notes: **{{< words-note >}} words**. You can also reliably count words in the footnotes which would have previously been included in whichever section they were.[^2]
 
-- Use `{{{< words-sum ARG >}}}` where `ARG` is some concatenation of the four countable areas: `body`, `ref`, `append`, and `note`. For example, `{{{< words-sum body-note >}}}` includes a count of the words in the body and notes (**{{{< words-sum body-note >}}} words**); `{{{< words-sum ref-append >}}}` includes a count of the words in the references and appendix (**{{{< words-sum ref-append >}}} words**)
+- Use `{{{< words-sum ARG >}}}` where `ARG` is some concatenation of the four countable areas: `body`, `ref`, `append`, and `note`. For example, `{{{< words-sum body-note >}}}` includes a count of the words in the body and notes (**{{< words-sum body-note >}} words**); `{{{< words-sum ref-append >}}}` includes a count of the words in the references and appendix (**{{< words-sum ref-append >}} words**)
 
 [^1]: **NOTE** shortcodes `{{{< words-body >}}}`, `{{{< words-ref >}}}`, `{{{< words-append >}}}`, and `{{{< words-note >}}}` do not overlap their counts.
 


### PR DESCRIPTION
I still dont have quarto 1.5 installed, but #5 also failed with the updated template on 1.4.553. This update should addresses #6 for quarto 1.4.553. @andrewheiss could you test this PR against your quarto version?