### PR TITLE
Stop duplicating workflow triggers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,11 @@ name: testing
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This *should* make it so only one set of tests is run when there's a PR